### PR TITLE
Installs, but fails to work on OS X Lion

### DIFF
--- a/lib/net/snmp/mib.rb
+++ b/lib/net/snmp/mib.rb
@@ -3,13 +3,13 @@ module Net
   module SNMP
     module MIB
       def self.init
-        Wrapper.init_mib
+        Wrapper.netsnmp_init_mib
       end
-      
+
       def self.read_all_mibs
         Wrapper.read_all_mibs
       end
-      
+
       def self.get_node(oid)
         Node.get_node(oid)
       end
@@ -22,9 +22,9 @@ module Net
         Wrapper.read_mib(filename)
       end
       def self.read_module(name)
-        Wrapper.read_module(name)
+        Wrapper.netsnmp_read_module(name)
       end
-      
+
     end
   end
 end

--- a/lib/net/snmp/wrapper.rb
+++ b/lib/net/snmp/wrapper.rb
@@ -56,9 +56,9 @@ module Wrapper
            :data, :pointer,
            :dataFreeHook, callback([ :pointer ], :void),
            :index, :int
-    )  
+    )
   end
-  
+
   #puts "VariableList size = #{VariableList.size}"
 
   def self.print_pdu(p)
@@ -76,7 +76,7 @@ module Wrapper
       print_varbind(var)
       v = var.next_variable
     end
-    
+
   end
   class SnmpPdu < NiceFFI::Struct
     layout(
@@ -299,7 +299,7 @@ module Wrapper
   attach_function :snmp_pdu_type, [ :int ], :string
 
 
-  
+
   attach_function :asn_check_packet, [ :pointer, :uint ], :int
   attach_function :asn_parse_int, [ :pointer, :pointer, :pointer, :pointer, :uint ], :pointer
   attach_function :asn_build_int, [ :pointer, :pointer, :u_char, :pointer, :uint ], :pointer
@@ -338,7 +338,7 @@ module Wrapper
   attach_function :snmp_api_errstring, [ :int ], :string
   attach_function :snmp_perror, [ :string ], :void
   attach_function :snmp_set_detail, [ :string ], :void
-  
+
   attach_function :snmp_select_info, [:pointer, :pointer, :pointer, :pointer], :int
   attach_function :snmp_read, [:pointer], :void
   attach_function :generate_Ku, [:pointer, :int, :string, :int, :pointer, :pointer], :int
@@ -346,11 +346,11 @@ module Wrapper
 
 
   # MIB functions
-  attach_function :init_mib, [], :void
+  attach_function :netsnmp_init_mib, [], :void
   attach_function :read_all_mibs, [], :void
   attach_function :add_mibdir, [:string], :int
   attach_function :read_mib, [:string], Tree.typed_pointer
-  attach_function :read_module, [:string], Tree.typed_pointer
+  attach_function :netsnmp_read_module, [:string], Tree.typed_pointer
   attach_function :snmp_set_save_descriptions, [:int], :void
 
   attach_function :get_tree_head, [], Tree.typed_pointer
@@ -362,7 +362,7 @@ module Wrapper
   def self.get_fd_set
     FFI::MemoryPointer.new(:pointer, 128)
   end
-  
+
 
 end
 end


### PR DESCRIPTION
Ruby 1.9.2-p290
net-snmp 0.2.3

OS X Lion comes with libnetsnmp pre-installed on the system in /usr/include/libnetsnmp.dylib. Judging by `snmpget --version`, this is version 5.6 of libnetsnmp.

The net-snmp gem installs successfully, but when a simple test script is run, it errors out. The test script and the error can be seen in https://gist.github.com/1165678.

After running `nm /usr/include/libnetsnmp.dylib`, I was able to determine that the init_mib and read_module functions have been renamed to netsnmp_init_mib and netsnmp_read_module, respectively. I forked this gem, made the changes in wrapper.rb and mib.rb, and it successfully resolved the issue. The changes I made can be seen in this commit https://github.com/bjreath/net-snmp/commit/4c2991777e9fc5b71dc50ea2703cdca6ff09da47 of my fork.

I'm not sure if this will work on other platforms, but I'm opening this issue and linking to the resolution to start a dialog on how to get this fixed and rolled into the main gem repository.

Thanks!
