### PR TITLE
Fix password length for utf-8 encoded chars (http://zargony.com/2009/07/...

### DIFF
--- a/lib/net/snmp/session.rb
+++ b/lib/net/snmp/session.rb
@@ -171,10 +171,12 @@ module Net
       def close
         if Net::SNMP.thread_safe
           self.class.lock.synchronize {
-            Wrapper.snmp_sess_close(@struct)
+            Wrapper..shutdown_usm()
+	    Wrapper.snmp_sess_close(@struct)
             self.class.sessions.delete(self.sessid)
           }
         else
+          Wrapper..shutdown_usm()
           Wrapper.snmp_sess_close(@struct)
           self.class.sessions.delete(self.sessid)
         end

--- a/lib/net/snmp/session.rb
+++ b/lib/net/snmp/session.rb
@@ -176,7 +176,7 @@ module Net
             self.class.sessions.delete(self.sessid)
           }
         else
-          Wrapper..shutdown_usm()
+          Wrapper.shutdown_usm()
           Wrapper.snmp_sess_close(@struct)
           self.class.sessions.delete(self.sessid)
         end

--- a/lib/net/snmp/session.rb
+++ b/lib/net/snmp/session.rb
@@ -136,7 +136,7 @@ module Net
             auth_key_result = Wrapper.generate_Ku(@sess.securityAuthProto,
                                              @sess.securityAuthProtoLen,
                                              options[:auth_password],
-                                             options[:auth_password].length,
+                                             options[:auth_password].bytesize,
                                              @sess.securityAuthKey,
                                              auth_len_ptr)
             @sess.securityAuthKeyLen = auth_len_ptr.read_int
@@ -150,7 +150,7 @@ module Net
               priv_key_result = Wrapper.generate_Ku(@sess.securityAuthProto,
                                                @sess.securityAuthProtoLen,
                                                options[:priv_password],
-                                               options[:priv_password].length,
+                                               options[:priv_password].bytesize,
                                                @sess.securityPrivKey,
                                                priv_len_ptr)
               @sess.securityPrivKeyLen = priv_len_ptr.read_int

--- a/lib/net/snmp/wrapper.rb
+++ b/lib/net/snmp/wrapper.rb
@@ -358,6 +358,8 @@ module Wrapper
   #attach_function :send_easy_trap, [:int, :int], :void
   #attach_function :send_trap_vars, [:int, :int, :pointer], :void
   #attach_function :send_v2trap, [:pointer], :void
+  
+  attach_function :shutdown_usm, [], :void
 
   def self.get_fd_set
     FFI::MemoryPointer.new(:pointer, 128)


### PR DESCRIPTION
http://zargony.com/2009/07/24/ruby-1-9-and-file-encodings

UTF-8 chars (like é, è, ç) are encoded by a double byte in stead of a normal sized 1 byte char. So, it is better to use the bytesize of the password string in stead of the length of the string, otherwise the password strings loose some bytes at the end.
